### PR TITLE
update to work with http/2 and chrome 60

### DIFF
--- a/uploader/uploader.ts
+++ b/uploader/uploader.ts
@@ -40,9 +40,8 @@ export class Uploader {
         };
 
         xhr.onload = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            const contentType = headers['Content-Type'] || headers['content-type'];
-            let response = this.parseResponse(contentType, xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
+            let response = this.parseResponse(headers['content-type'], xhr.response);
             if(this.isSuccessStatus(xhr.status)) {
                 this.onSuccessUpload(item, response, xhr.status, headers);
             } else {
@@ -52,17 +51,15 @@ export class Uploader {
         };
 
         xhr.onerror = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            const contentType = headers['Content-Type'] || headers['content-type'];
-            let response = this.parseResponse(contentType, xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
+            let response = this.parseResponse(headers['content-type'], xhr.response);
             this.onErrorUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };
 
         xhr.onabort = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            const contentType = headers['Content-Type'] || headers['content-type'];
-            let response = this.parseResponse(contentType, xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
+            let response = this.parseResponse(headers['content-type'], xhr.response);
             this.onCancelUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };

--- a/uploader/uploader.ts
+++ b/uploader/uploader.ts
@@ -40,8 +40,8 @@ export class Uploader {
         };
 
         xhr.onload = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
-            let response = this.parseResponse(headers['content-type'], xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
+            let response = this.parseResponse(xhr.getResponseHeader('content-type'), xhr.response);
             if(this.isSuccessStatus(xhr.status)) {
                 this.onSuccessUpload(item, response, xhr.status, headers);
             } else {
@@ -51,15 +51,15 @@ export class Uploader {
         };
 
         xhr.onerror = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
-            let response = this.parseResponse(headers['content-type'], xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
+            let response = this.parseResponse(xhr.getResponseHeader('content-type'), xhr.response);
             this.onErrorUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };
 
         xhr.onabort = () => {
-            let headers = this.parseHeaders(xhr.getAllResponseHeaders().toLowerCase());
-            let response = this.parseResponse(headers['content-type'], xhr.response);
+            let headers = this.parseHeaders(xhr.getAllResponseHeaders());
+            let response = this.parseResponse(xhr.getResponseHeader('content-type'), xhr.response);
             this.onCancelUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };

--- a/uploader/uploader.ts
+++ b/uploader/uploader.ts
@@ -41,7 +41,8 @@ export class Uploader {
 
         xhr.onload = () => {
             let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            let response = this.parseResponse(headers['Content-Type'], xhr.response);
+            const contentType = headers['Content-Type'] || headers['content-type'];
+            let response = this.parseResponse(contentType, xhr.response);
             if(this.isSuccessStatus(xhr.status)) {
                 this.onSuccessUpload(item, response, xhr.status, headers);
             } else {
@@ -52,14 +53,16 @@ export class Uploader {
 
         xhr.onerror = () => {
             let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            let response = this.parseResponse(headers['Content-Type'], xhr.response);
+            const contentType = headers['Content-Type'] || headers['content-type'];
+            let response = this.parseResponse(contentType, xhr.response);
             this.onErrorUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };
 
         xhr.onabort = () => {
             let headers = this.parseHeaders(xhr.getAllResponseHeaders());
-            let response = this.parseResponse(headers['Content-Type'], xhr.response);
+            const contentType = headers['Content-Type'] || headers['content-type'];
+            let response = this.parseResponse(contentType, xhr.response);
             this.onCancelUpload(item, response, xhr.status, headers);
             this.onCompleteUpload(item, response, xhr.status, headers);
         };


### PR DESCRIPTION
Google Chrome 60 has started to convert HTTP headers to lowercase.  For example, `xhr.getAllResponseHeaders()` will return items such as `content-type` instead of `Content-Type`.  This is due to a change in the HTTP/2 spec, which all headers will be lowercase.  So this appears to be a permanent change.  I have updated the source code to handle both cases.